### PR TITLE
Feitos ajustes para mapeamento de campos KPMG

### DIFF
--- a/oic_db/queries/conciliated_payed_receivable/select_conciliated_payed_receivable.sql
+++ b/oic_db/queries/conciliated_payed_receivable/select_conciliated_payed_receivable.sql
@@ -6,14 +6,19 @@ select
     ,cpr.bank_number
     ,cpr.bank_branch
     ,cpr.bank_account
-	,cpr.created_at
+    ,cpr.gross_value
+	,date_format(cpr.created_at, '%y%m%d') as Deposit_Date
+    ,time (cpr.created_at) as credit_hour 
     ,concat ('RD_',cpr.bank_number,'_',cpr.bank_branch,'_',cpr.bank_account) as Receipt_Method
+    ,RTRIM (concat('RD_',cpr.bank_number,'_',cpr.bank_branch,'_',cpr.bank_account,'_',rec.credit_date)) as Lote_Name
+    ,RTRIM (concat(crc.identification_financial_responsible,'Faturar')) as Customer_Site
     ,rec.conciliator_id
     ,rec.credit_card_brand
     ,rec.contract_number
     ,rec.transaction_type
     ,rec.credit_date
     ,rec.credit_card_brand
+    ,rec.erp_receivable_id
     ,if (rec.transaction_type in ('credit_card_recurring','credit_card_tef','credit_card_pos','online_credit_card'), 'CARTOES DE CREDITO', 
           if (rec.transaction_type = 'debit_account_recurring', 'DEPOSITO EM CONTA CORRENTE', 
  		     if (rec.transaction_type in ('debit_card_tef','debit_card_pos','online_debit_card'), 'CARTOES DE DEBITO', 
@@ -55,3 +60,7 @@ and rec.erp_receivable_id is not null
 and cpr.erp_receipt_status_transaction = 'waiting_to_be_process'
 and cpr.erp_receipt_id is null
 and cpr.concitiation_type = 'PCV'; -- Considerar somente os retornos de comprovante de recebimento enviado pela conciliadora
+
+
+
+


### PR DESCRIPTION
Formato da data: aammdd -> 191213
Acrescentado na query o campo Deposit_Date: 
(date_format(cpr.created_at, '%y%m%d') as Deposit_Date)
Alterado no documento de mapeamento tbm
=--=-=-=---=--=--=-=-=
created_hour - Segundo o documento e a planilha exemplo da Maristel, formato hh:mm:ss -> 17:20:33
Acrescentado na query campo credit_hour
time (cpr.created_at) as credit_hour
Alterado no documento de mapeamento tbm
=--=--==--==--=--=-=
Lote_Name - não está na query e não é um campo de tabela. Aguardando definição
Acrescentado na query o campo Lote_Name
RTRIM (concat('RD_',cpr.bank_number,'_',cpr.bank_branch,'_',cpr.bank_account,'_',rec.credit_date)) as Lote_Name
Não foi necessária alteração na query de mapeamento
-=-=-=-=--=-=-=
cpr.gross_value e rec.erp_receivable_id - Não estavam na query. Inseridos na query de crédito
Acrescentados na query os campos cpr.gross_value e rec.erp_receivable_id
Não foi necessária alteração na query de mapeamento
-==--=-=-=-=-=-=-=-=-
Também estava faltando o campo Customer_Site na query, acrescentado.